### PR TITLE
Run: print raised exception on stdout

### DIFF
--- a/pimdm/Main.py
+++ b/pimdm/Main.py
@@ -38,10 +38,17 @@ def add_membership_interface(interface_name, ipv4=True, ipv6=False):
             add_membership_interface(interface_name, ipv4, ipv6)
         return
 
-    if ipv4 and kernel is not None:
-        kernel.create_membership_interface(interface_name=interface_name)
-    if ipv6 and kernel_v6 is not None:
-        kernel_v6.create_membership_interface(interface_name=interface_name)
+    try:
+        if ipv4 and kernel is not None:
+            kernel.create_membership_interface(interface_name=interface_name)
+        if ipv6 and kernel_v6 is not None:
+            kernel_v6.create_membership_interface(interface_name=interface_name)
+    except Exception as e:
+        e.args = (
+            'Failed to create membership interface for %s\n%s' % (interface_name, e.args[0]),
+            *e.args[1:],
+        )
+        raise e
 
 
 def remove_interface(interface_name, pim=False, membership=False, ipv4=True, ipv6=False):

--- a/pimdm/Run.py
+++ b/pimdm/Run.py
@@ -115,7 +115,8 @@ class MyDaemon(Daemon):
                     connection.sendall(pickle.dumps(Main.get_config()))
                 elif 'drop' in args and args.drop:
                     Main.drop(args.drop[0], int(args.drop[1]))
-            except Exception:
+            except Exception as e:
+                connection.sendall(pickle.dumps(e))
                 connection.shutdown(socket.SHUT_RDWR)
                 traceback.print_exc()
             finally:


### PR DESCRIPTION
- Run : Print on stdout the exception that occured to explicitely aware the user
that a command failed.
- Main : Add membership interface creation failure to error message when an
exception is raised in `add_membership_interface` method