### PR TITLE
Interface: fix drop_packet_type missing attribute

### DIFF
--- a/pimdm/Interface.py
+++ b/pimdm/Interface.py
@@ -18,6 +18,8 @@ class Interface(metaclass=ABCMeta):
         self._recv_socket = recv_socket
         self.interface_enabled = False
 
+        self.drop_packet_type = None
+
     def _enable(self):
         """
         Enable this interface

--- a/pimdm/InterfacePIM.py
+++ b/pimdm/InterfacePIM.py
@@ -78,8 +78,6 @@ class InterfacePim(Interface):
         # don't receive outgoing packets
         s.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_LOOP, 0)
 
-        self.drop_packet_type = None
-
         super().__init__(interface_name, s, s, vif_index)
         super()._enable()
         self.force_send_hello()


### PR DESCRIPTION
Fix the following error:

```
Exception in thread Thread-4:
Traceback (most recent call last):
  File "/usr/lib/python3.7/threading.py", line 917, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.7/threading.py", line 1166, in run
    self.function(*self.args, **self.kwargs)
  File "/usr/local/lib/python3.7/dist-packages/pimdm/InterfacePIM.py", line 152, in send_hello
    self.send(packet.bytes())
  File "/usr/local/lib/python3.7/dist-packages/pimdm/InterfacePIM6.py", line 86, in send
    super().send(data=data, group_ip=group_ip)
  File "/usr/local/lib/python3.7/dist-packages/pimdm/InterfacePIM.py", line 113, in send
    if self.drop_packet_type is not None:
AttributeError: 'InterfacePim6' object has no attribute 'drop_packet_type'
```