### PR TITLE
Config.py: Use some interfaces even if other fail

### DIFF
--- a/pimdm/InterfacePIM.py
+++ b/pimdm/InterfacePIM.py
@@ -54,7 +54,11 @@ class InterfacePim(Interface):
         self.interface_logger = logging.LoggerAdapter(InterfacePim.LOGGER, {'vif': vif_index, 'interfacename': interface_name})
 
         # SOCKET
-        ip_interface = netifaces.ifaddresses(interface_name)[netifaces.AF_INET][0]['addr']
+        if_addr_dict = netifaces.ifaddresses(interface_name)
+        if not netifaces.AF_INET in if_addr_dict:
+            raise Exception("Adding PIM interface failed because %s does not "
+                            "have any ipv4 address" % interface_name)
+        ip_interface = if_addr_dict[netifaces.AF_INET][0]['addr']
         self.ip_interface = ip_interface
 
         s = socket.socket(socket.AF_INET, socket.SOCK_RAW, socket.IPPROTO_PIM)


### PR DESCRIPTION
Allow to run PIM, IGMP or MLD on working interfaces even if it failed for other interfaces listed in the configuration file.