### PR TITLE
setup.py: Add setuptools support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ if len(sys.argv) >= 2 and sys.argv[1] == "install" and sys.version_info < (3, 3)
     raise SystemExit("Python 3.3 or higher is required")
 
 
-dependencies = open("requirements.txt", "r").read().splitlines()
 setup(
     name="pim-dm",
     description="PIM-DM protocol",
@@ -18,7 +17,14 @@ setup(
     author="Pedro Oliveira",
     author_email="pedro.francisco.oliveira@tecnico.ulisboa.pt",
     license="MIT",
-    install_requires=dependencies,
+    install_requires=[
+        'PrettyTable',
+        'netifaces',
+        'ipaddress',
+        'pyroute2',
+        'py-mld==1.0.2',
+        'igmp==1.0.2',
+    ],
     packages=find_packages(exclude=["docs"]),
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
Reading `install_requires` from `requirements.txt` makes it impossible to install from pypi archive by simply running `python setup.py install` as `requirements.txt` is not part of the archive (see [pim-dm-1.3.3](https://files.pythonhosted.org/packages/0f/ef/9765a66b61ed68442dc1ee68befb690dbca33eede267df4ce6900a3fe7ac/pim-dm-1.3.3.tar.gz) by example).
As wrote in [Python Packaging documentation](https://packaging.python.org/en/latest/discussions/install-requires-vs-requirements/) `requirements.txt` should be used to reproduce an environment (generated by `pip freeze` by example) and so changed for each release if needed where `install_requires` should only declare minimal requirements.